### PR TITLE
Fix broken link for Flipstarter EC plugin

### DIFF
--- a/views/index.html
+++ b/views/index.html
@@ -258,7 +258,7 @@
                     <small data-string="instructionsLabel"></small>
                     <p id="instructions" data-string="instructions"></p>
                     <div class="button-container">
-                        <a id="downloadButton" class="btn" href="https://gitlab.com/flipstarter/flipstarter-electron-cash/uploads/ec6b5a7518801c4a278128ac4f296607/flipstarter-1.4.zip">
+                        <a id="downloadButton" class="btn" href="https://gitlab.com/flipstarter/flipstarter-electron-cash/uploads/b5300ea76722e60d6943521d3183b046/flipstarter-1.4.zip">
                           <i class="icon-download"></i>
                           <span data-string="downloadText"></span>
                         </a>


### PR DESCRIPTION
Fixed broken link:

https://gitlab.com/flipstarter/flipstarter-electron-cash/uploads/ec6b5a7518801c4a278128ac4f296607/flipstarter-1.4.zip

To this:
https://gitlab.com/flipstarter/flipstarter-electron-cash/uploads/b5300ea76722e60d6943521d3183b046/flipstarter-1.4.zip

According to:

https://gitlab.com/flipstarter/flipstarter-electron-cash/-/releases/v1.4.0